### PR TITLE
Changes to containers

### DIFF
--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -101,22 +101,25 @@ jobs:
           echo rver=$(cat rver) >> $GITHUB_OUTPUT
           echo biocver=$(cat biocver) >> $GITHUB_OUTPUT
           echo osver=$(awk -F= '/VERSION_ID/ {gsub("\"", "", $2); print $2}' os-release) >> $GITHUB_OUTPUT
+          BASEPREFIX=""
+          if [ 'devel' == 'devel' ]; then BASEPREFIX="devel-"; fi
+          echo baseprefix=$BASEPREFIX >> $GITHUB_OUTPUT
 
       - name: Export digest by ubuntu and r versions
         run: |
           digest="${{ steps.build.outputs.digest }}"
-          mkdir -p /tmp/digests/${{matrix.ubuntu}}
-          touch "/tmp/digests/${{matrix.ubuntu}}/${digest#sha256:}"
-          mkdir -p /tmp/digests/${{matrix.ubuntu}}-bioc-${{steps.versions.outputs.biocver}}
-          touch "/tmp/digests/${{matrix.ubuntu}}-bioc-${{steps.versions.outputs.biocver}}/${digest#sha256:}"
-          mkdir -p /tmp/digests/${{matrix.ubuntu}}-bioc-${{steps.versions.outputs.biocver}}-r-${{steps.versions.outputs.rver}}
-          touch "/tmp/digests/${{matrix.ubuntu}}-bioc-${{steps.versions.outputs.biocver}}-r-${{steps.versions.outputs.rver}}/${digest#sha256:}"
-          mkdir -p /tmp/digests/${{steps.versions.outputs.osver}}
-          touch "/tmp/digests/${{steps.versions.outputs.osver}}/${digest#sha256:}"
-          mkdir -p /tmp/digests/${{steps.versions.outputs.osver}}-bioc-${{steps.versions.outputs.biocver}}
-          touch "/tmp/digests/${{steps.versions.outputs.osver}}-bioc-${{steps.versions.outputs.biocver}}/${digest#sha256:}"
-          mkdir -p /tmp/digests/${{steps.versions.outputs.osver}}-bioc-${{steps.versions.outputs.biocver}}-r-${{steps.versions.outputs.rver}}
-          touch "/tmp/digests/${{steps.versions.outputs.osver}}-bioc-${{steps.versions.outputs.biocver}}-r-${{steps.versions.outputs.rver}}/${digest#sha256:}"
+          mkdir -p /tmp/digests/${{steps.versions.outputs.baseprefix}}${{matrix.ubuntu}}
+          touch "/tmp/digests/${{steps.versions.outputs.baseprefix}}${{matrix.ubuntu}}/${digest#sha256:}"
+          mkdir -p /tmp/digests/${{steps.versions.outputs.baseprefix}}${{matrix.ubuntu}}-bioc-${{steps.versions.outputs.biocver}}
+          touch "/tmp/digests/${{steps.versions.outputs.baseprefix}}${{matrix.ubuntu}}-bioc-${{steps.versions.outputs.biocver}}/${digest#sha256:}"
+          mkdir -p /tmp/digests/${{steps.versions.outputs.baseprefix}}${{matrix.ubuntu}}-bioc-${{steps.versions.outputs.biocver}}-r-${{steps.versions.outputs.rver}}
+          touch "/tmp/digests/${{steps.versions.outputs.baseprefix}}${{matrix.ubuntu}}-bioc-${{steps.versions.outputs.biocver}}-r-${{steps.versions.outputs.rver}}/${digest#sha256:}"
+          mkdir -p /tmp/digests/${{steps.versions.outputs.baseprefix}}${{steps.versions.outputs.osver}}
+          touch "/tmp/digests/${{steps.versions.outputs.baseprefix}}${{steps.versions.outputs.osver}}/${digest#sha256:}"
+          mkdir -p /tmp/digests/${{steps.versions.outputs.baseprefix}}${{steps.versions.outputs.osver}}-bioc-${{steps.versions.outputs.biocver}}
+          touch "/tmp/digests/${{steps.versions.outputs.baseprefix}}${{steps.versions.outputs.osver}}-bioc-${{steps.versions.outputs.biocver}}/${digest#sha256:}"
+          mkdir -p /tmp/digests/${{steps.versions.outputs.baseprefix}}${{steps.versions.outputs.osver}}-bioc-${{steps.versions.outputs.biocver}}-r-${{steps.versions.outputs.rver}}
+          touch "/tmp/digests/${{steps.versions.outputs.baseprefix}}${{steps.versions.outputs.osver}}-bioc-${{steps.versions.outputs.biocver}}-r-${{steps.versions.outputs.rver}}/${digest#sha256:}"
 
       - name: Upload digests
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -76,7 +76,7 @@ jobs:
           cat << "EOF" > ${{matrix.ubuntu}}-${{matrix.platform}}-r.Dockerfile
           FROM ${{ steps.vars.outputs.container }}@${{ steps.build.outputs.digest }} as extract
           USER root
-          RUN mkdir /bioctmp && /bbs_r_start -e 'BiocManager::version()' | grep '\[1\]' | awk -F"'" '{print $2}' > /bioctmp/biocver && /bbs_r_start -e 'cat(paste(version$major, version$minor, sep = "."))' > /bioctmp/rver && cat /etc/os-release > /bioctmp/os-release
+          RUN mkdir /bioctmp && /bbs_r_start -e 'BiocManager::version()' | grep '\[1\]' | awk -F"'" '{print $2}' > /bioctmp/biocver && /bbs_r_start --slave -e 'cat(paste(version$major, version$minor, sep = "."))' > /bioctmp/rver && cat /etc/os-release > /bioctmp/os-release
           FROM scratch as export
           COPY --from=extract /bioctmp/* /
           EOF

--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -102,7 +102,7 @@ jobs:
           echo biocver=$(cat biocver) >> $GITHUB_OUTPUT
           echo osver=$(awk -F= '/VERSION_ID/ {gsub("\"", "", $2); print $2}' os-release) >> $GITHUB_OUTPUT
           BASEPREFIX=""
-          if [ 'devel' == 'devel' ]; then BASEPREFIX="devel-"; fi
+          if [ '${{matrix.ubuntu}}' == 'devel' ]; then BASEPREFIX="devel-"; fi
           echo baseprefix=$BASEPREFIX >> $GITHUB_OUTPUT
 
       - name: Export digest by ubuntu and r versions

--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -76,7 +76,7 @@ jobs:
           cat << "EOF" > ${{matrix.ubuntu}}-${{matrix.platform}}-r.Dockerfile
           FROM ${{ steps.vars.outputs.container }}@${{ steps.build.outputs.digest }} as extract
           USER root
-          RUN mkdir /bioctmp && /bbs_r_start -e 'BiocManager::version()' | grep '\[1\]' | awk -F"'" '{print $2}' > /bioctmp/biocver && /bbs_r_start --version > /bioctmp/rver && cat /etc/os-release > /bioctmp/os-release
+          RUN mkdir /bioctmp && /bbs_r_start -e 'BiocManager::version()' | grep '\[1\]' | awk -F"'" '{print $2}' > /bioctmp/biocver && /bbs_r_start -e 'cat(paste(version$major, version$minor, sep = "."))' > /bioctmp/rver && cat /etc/os-release > /bioctmp/os-release
           FROM scratch as export
           COPY --from=extract /bioctmp/* /
           EOF
@@ -98,7 +98,7 @@ jobs:
         run: |
           cd ${{matrix.ubuntu}}-${{matrix.platform}}
           tar -xvf r.tar
-          echo rver=$(cat rver | awk 'NR==1{print $3}') >> $GITHUB_OUTPUT
+          echo rver=$(cat rver) >> $GITHUB_OUTPUT
           echo biocver=$(cat biocver) >> $GITHUB_OUTPUT
           echo osver=$(awk -F= '/VERSION_ID/ {gsub("\"", "", $2); print $2}' os-release) >> $GITHUB_OUTPUT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ USER biocbuild
 COPY . /home/biocbuild/bioconductor_salt
 WORKDIR /home/biocbuild
 RUN bash bioconductor_salt/startup_bbs_standalone_${CYCLE}.sh
-ENTRYPOINT ["/bbs_r_start"]
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["/bbs_r_start"]
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,33 @@
 This repository contains the SaltStack formulas to configure an Ubuntu or a
 MacOS machine for the [Bioconductor Build System](https://github.com/Bioconductor/BBS).
 
-It also builds [BBS
+It also builds [BBS-like
 containers](https://github.com/Bioconductor/bioconductor_salt/pkgs/container/bioconductor_salt).
+
+### Simulating the BBS Ubuntu environment in a container
+We are experimentally building and publishing containers under the name `ghcr.io/bioconductor/bioconductor_salt`,
+which can be used to mimic a BBS-like linux environment, in hopes of easing reproducibility and interactive debugging
+of the BBS environment for package developers.
+We currently offer containers for both `release` and `devel` Bioconductor versions with Ubuntu `jammy` (`22.04`).
+Container tags with various version pinnings can be used to acquire a particular environment, following the schema
+`[ubuntu_version]-bioc-[bioc_version]-r-[r_version]` eg `jammy-bioc-3.18-r-4.3.2` or `22.04-bioc-3.18-r-4.3.2`, where
+each level is optional. For example, one could use tag `jammy-bioc-3.18` or `22.04-bioc-3.18` to get the latest 3.18,
+regardless of R version, or even simply `jammy`/`22.04` to get the latest release container.
+`devel-` will prefix all devel container tags, followed by the same schema described above.
+
+All containers will use the R command if no command is specified. Below are some examples for running the container.
+```
+# Interactive R session
+docker run -it ghcr.io/bioconductor/bioconductor_salt:jammy
+# is equivalent to
+docker run -it ghcr.io/bioconductor/bioconductor_salt:jammy R
+
+# Bash shell
+docker run -it ghcr.io/bioconductor/bioconductor_salt:jammy bash
+
+# Rscript
+docker run -it ghcr.io/bioconductor/bioconductor_salt:jammy "Rscript --version"
+```
 
 ### Configuring for Ubuntu 22.04
 

--- a/startup_bbs_standalone_devel.sh
+++ b/startup_bbs_standalone_devel.sh
@@ -43,6 +43,9 @@ echo "$RPATH/R \"\$@\"" | sudo tee -a /bbs_r_start
 sudo chown biocbuild /bbs_r_start
 sudo chmod +x /bbs_r_start
 
+sudo ln -s /home/biocbuild/bbs-*-bioc/R/bin/R /usr/bin/R
+sudo ln -s /home/biocbuild/bbs-*-bioc/R/bin/Rscript /usr/bin/Rscript
+
 # Cleanup
 # rm -rf /srv /etc/salt
 # sudo apt-get -y purge salt-minion

--- a/startup_bbs_standalone_release.sh
+++ b/startup_bbs_standalone_release.sh
@@ -43,6 +43,9 @@ echo "$RPATH/R \"\$@\"" | sudo tee -a /bbs_r_start
 sudo chown biocbuild /bbs_r_start
 sudo chmod +x /bbs_r_start
 
+sudo ln -s /home/biocbuild/bbs-*-bioc/R/bin/R /usr/bin/R
+sudo ln -s /home/biocbuild/bbs-*-bioc/R/bin/Rscript /usr/bin/Rscript
+
 # Cleanup
 # rm -rf /srv /etc/salt
 # sudo apt-get -y purge salt-minion


### PR DESCRIPTION
- Changes default as discussed a few weeks ago: defaults to R, but can change by modifying command not entrypoint.
- Adds `devel-` prefix for devel containers, to make them easier to identify after the fact (not have 3.19 release replace previous 3.19 from devel)
- Changes R version detection to use `version$major|minor` so that it is always numeric (right now is detecting `r-development`)
- Adds README section summarizing container usage