### PR TITLE
319 release prep

### DIFF
--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -107,6 +107,13 @@ jobs:
 
       - name: Export digest by ubuntu and r versions
         run: |
+          R_VER_EXPECTED=$(curl https://bioconductor.org/config.yaml | yq e '.r_ver_for_bioc_ver."${{steps.versions.outputs.biocver}}"')
+          R_VER_FOUND="${{steps.versions.outputs.rver}}"
+          R_FOUND_MAJOR_MINOR=${R_VER_FOUND%.*}
+          if [ "$R_FOUND_MAJOR_MINOR" != "$R_VER_EXPECTED" ]; then
+            echo "Mismatched versions found '$R_VER_FOUND' and expected '$R_VER_EXPECTED'"
+            exit 1
+          fi
           digest="${{ steps.build.outputs.digest }}"
           mkdir -p /tmp/digests/${{steps.versions.outputs.baseprefix}}${{matrix.ubuntu}}
           touch "/tmp/digests/${{steps.versions.outputs.baseprefix}}${{matrix.ubuntu}}/${digest#sha256:}"

--- a/saltstack/pillar/custom/devel_standalone.sls
+++ b/saltstack/pillar/custom/devel_standalone.sls
@@ -4,8 +4,8 @@
 {% set version = '3.20' %}
 {% set environment = 'dev' %} {# Use 'dev' or 'prod' #}
 {% set r_download = 'https://cran.r-project.org/src/base/R-4/R-4.4.0.tar.gz' %}
-{% set r_version = 'R-4.5' %}
-{% set r_previous_version = 'R-4.4' %}
+{% set r_version = 'R-4.4' %}
+{% set r_previous_version = 'R-4.3' %}
 {% set cycle = 'devel' %} {# Use 'devel' for Spring to Fall, 'patch' for Fall to Spring #}
 {% set name = 'bbs-machine' %}
 {% set immunespace_pwd = '' %}

--- a/saltstack/pillar/custom/devel_standalone.sls
+++ b/saltstack/pillar/custom/devel_standalone.sls
@@ -1,12 +1,12 @@
 {# Custom Settings #}
 
 {% set branch = 'devel' %} {# Use 'release' or 'devel' #}
-{% set version = '3.19' %}
+{% set version = '3.20' %}
 {% set environment = 'dev' %} {# Use 'dev' or 'prod' #}
 {% set r_download = 'https://stat.ethz.ch/R/daily/R-devel.tar.gz' %}
-{% set r_version = 'R-4.4' %}
-{% set r_previous_version = 'R-4.3' %}
-{% set cycle = 'patch' %} {# Use 'devel' for Spring to Fall, 'patch' for Fall to Spring #}
+{% set r_version = 'R-4.5' %}
+{% set r_previous_version = 'R-4.4' %}
+{% set cycle = 'devel' %} {# Use 'devel' for Spring to Fall, 'patch' for Fall to Spring #}
 {% set name = 'bbs-machine' %}
 {% set immunespace_pwd = '' %}
 {% set create_users = False %}

--- a/saltstack/pillar/custom/devel_standalone.sls
+++ b/saltstack/pillar/custom/devel_standalone.sls
@@ -3,7 +3,7 @@
 {% set branch = 'devel' %} {# Use 'release' or 'devel' #}
 {% set version = '3.20' %}
 {% set environment = 'dev' %} {# Use 'dev' or 'prod' #}
-{% set r_download = 'https://stat.ethz.ch/R/daily/R-devel.tar.gz' %}
+{% set r_download = 'https://cran.r-project.org/src/base/R-4/R-4.4.0.tar.gz' %}
 {% set r_version = 'R-4.5' %}
 {% set r_previous_version = 'R-4.4' %}
 {% set cycle = 'devel' %} {# Use 'devel' for Spring to Fall, 'patch' for Fall to Spring #}

--- a/saltstack/pillar/custom/release_standalone.sls
+++ b/saltstack/pillar/custom/release_standalone.sls
@@ -1,12 +1,12 @@
 {# Custom Settings #}
 
 {% set branch = 'release' %} {# Use 'release' or 'devel' #}
-{% set version = '3.18' %}
+{% set version = '3.19' %}
 {% set environment = 'dev' %} {# Use 'dev' or 'prod' #}
-{% set r_download = 'https://cran.r-project.org/src/base/R-4/R-4.3.3.tar.gz' %}
-{% set r_version = 'R-4.3' %}
-{% set r_previous_version = 'R-4.2' %}
-{% set cycle = 'patch' %} {# Use 'devel' for Spring to Fall, 'patch' for Fall to Spring #}
+{% set r_download = 'https://cran.r-project.org/src/base/R-4/R-4.4.0.tar.gz' %}
+{% set r_version = 'R-4.4' %}
+{% set r_previous_version = 'R-4.3' %}
+{% set cycle = 'devel' %} {# Use 'devel' for Spring to Fall, 'patch' for Fall to Spring #}
 {% set name = 'bbs-machine' %}
 {% set immunespace_pwd = '' %}
 {% set create_users = False %}

--- a/saltstack/pillar/custom/release_standalone.sls
+++ b/saltstack/pillar/custom/release_standalone.sls
@@ -6,7 +6,7 @@
 {% set r_download = 'https://cran.r-project.org/src/base/R-4/R-4.4.0.tar.gz' %}
 {% set r_version = 'R-4.4' %}
 {% set r_previous_version = 'R-4.3' %}
-{% set cycle = 'devel' %} {# Use 'devel' for Spring to Fall, 'patch' for Fall to Spring #}
+{% set cycle = 'patch' %} {# Use 'devel' for Spring to Fall, 'patch' for Fall to Spring #}
 {% set name = 'bbs-machine' %}
 {% set immunespace_pwd = '' %}
 {% set create_users = False %}


### PR DESCRIPTION
- Prepares updated versions for 3.19 release
- Adds version check to not tag images when R versions mismatch (eg [devel-jammy-bioc-3.19-r-4.5.0](https://github.com/orgs/Bioconductor/packages/container/bioconductor_salt/210614350?tag=devel-jammy-bioc-3.19-r-4.5.0) should not exist)