### PR TITLE
Update action versions and fix upload-artifact for v4

### DIFF
--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -27,11 +27,11 @@ jobs:
         with:
           verbose: true
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Extract metadata for container image
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -43,18 +43,18 @@ jobs:
           echo container=$(echo '${{ steps.meta.outputs.tags }}' | awk -F':' '{print $1}') >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
         if: contains(steps.versions.outputs.platform, 'arm64')
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           platforms: ${{matrix.platform}}
 
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build and push container image to ghcr
         id: build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           build-args: CYCLE=${{matrix.branch}}
           labels: ${{ steps.meta.outputs.labels }}
@@ -82,7 +82,7 @@ jobs:
           EOF
 
       - name: Build and push container image to ghcr
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           file: ${{matrix.ubuntu}}-${{matrix.platform}}-r.Dockerfile
           context: .
@@ -131,7 +131,7 @@ jobs:
       - name: Upload digests
         uses: actions/upload-artifact@v4
         with:
-          name: r2udigests-${{ github.run_id }}
+          name: digests-${{ matrix.branch }}-${{ github.run_id }}
           path: /tmp/digests/**
           if-no-files-found: error
           retention-days: 1
@@ -146,19 +146,27 @@ jobs:
       matrix:
         ubuntu: [jammy]
     steps:
-      - name: Download digests
+      - name: Download digests devel
         uses: actions/download-artifact@v4
         with:
-          name: r2udigests-${{ github.run_id }}
-          path: /tmp/digests
+          name: digests-devel-${{ github.run_id }}
+          path: /tmp/digests-devel
+
+      - name: Download digests release
+        uses: actions/download-artifact@v4
+        with:
+          name: digests-release-${{ github.run_id }}
+          path: /tmp/digests-release
+
+      - run: mkdir -p /tmp/digests && mv /tmp/digests-devel/* /tmp/digests/ && mv /tmp/digests-release/* /tmp/digests/
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           platforms: ${{matrix.platform}}
 
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -166,7 +174,7 @@ jobs:
 
       - name: Extract metadata for container image
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |


### PR DESCRIPTION
- Upgrades action versions
- Handles breaking change for artifact names introduced in `actions/upload-artifact@v4` (xref #2 in https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes)
